### PR TITLE
Migrate to new lecturers schema

### DIFF
--- a/readme.toml
+++ b/readme.toml
@@ -4,43 +4,39 @@ course_code = "MATH1004"
 
 description = ""
 
-[[lecturers]]
+[lecturers]
+[[lecturers.items]]
 name = "董志远"
 
-[[lecturers.reviews]]
+[[lecturers.items.reviews]]
 content = """
 授课风格：使用 PPT，课上会给出例题让大家在几分钟内做，然后给出解答。
 听课建议：有丰富的例题便于大家理解，建议按照老师的节奏听课和做例题。
 """
-
-[[lecturers]]
+[[lecturers.items]]
 name = "赵毅"
 
-[[lecturers.reviews]]
+[[lecturers.items.reviews]]
 content = """
 授课风格：太爱拓展了……他的拓展真的听不懂，听的时候注意下讲的在不在大纲里，但是拓展非常有用，特别是在炼丹的同学一定要听。讲的非常快，会抽问。
 听课建议：课前需要预习，不然跟不上，最后的习题课值得一听，一定要带书！！！纸质版的！！！
 """
 author = { name = "海边的星空", link = "", date = "2025-01" }
-
-[[lecturers]]
+[[lecturers.items]]
 name = "欧阳顺湘"
 
-[[lecturers.reviews]]
+[[lecturers.items.reviews]]
 content = "上课较为平淡，声音较小，坐后排会有听不清的情况，课上无 PPT，只有板书，但是有疑问还是可以请教老师，老师会耐心解答。老师是 $\\LaTeX$ 大师，自己写了一本教材，有 pdf 版本但是不外传，只在课程 qq 群 发过（每次上课都会修改，挺用心的），上课按照这个 pdf 讲，而不是课本。"
 author = { name = "Wei He", link = "https://github.com/hewei2001", date = "2020-01" }
-
-[[lecturers]]
+[[lecturers.items]]
 name = "王勇"
 
-[[lecturers.reviews]]
+[[lecturers.items.reviews]]
 content = """
 授课风格：老师是本部退休返聘到深圳的，也是教材的编者之一，水平很高，上课使用纯板书，按照课本的内容讲解并适当予以拓展。老师比较反感上课迟到的同学，会将他们请出教室，等到课间再允许进来。
 听课建议：老师年龄虽然大了，但很有精气神，而且纯板书上课，因此条理脉络非常清晰，非常推荐跟着老师的思路听课。
 """
 author = { name = "wpj", link = "https://github.com/wpj9362/", date = "2026-01" }
-
-
 [[sections]]
 title = "教材与线上资源"
 


### PR DESCRIPTION
Automated migration from legacy `[[lecturers]]` to new `[lecturers]` + `[[lecturers.items]]` + `[[lecturers.items.reviews]]` schema.

This is required for pr-server compatibility.